### PR TITLE
fix panic caused by PL_stack_sp changing during call_sv()

### DIFF
--- a/Attribute.xs
+++ b/Attribute.xs
@@ -84,7 +84,9 @@ apply_handler(pTHX_ pMY_CXT_ AV* const handler){
 
     PUTBACK;
 
-    PL_stack_sp -= call_sv(method, G_VOID | G_EVAL);
+    I32 retval;
+    retval = call_sv(method, G_VOID | G_EVAL);
+    PL_stack_sp -= retval;
 
     if(sv_true(ERRSV)){
         SV* const msg = sv_newmortal();

--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for Perl extension Sub::Attribute
 
+0.06
+    - Fix panic caused by PL_stack_sp moving during call_sv() (since perl
+      v5.19.x) [RT #107588]
+
 0.05 Tue Jan 19 11:10:46 2010
     - Work around RT #53776 (Thanks to Andreas Koenig)
     - Work around RT #53793 (Thanks to Markus Peter)


### PR DESCRIPTION
Sometime during the 5.19.x branch, it became possible that the perl
stack gets reallocated and moved during call_sv().  This results in a
panic because PL_stack_sp in Sub::Attribute gets overwritten with the
OLD value instead of the reallocated pointer.

This patch accounts for the fact that PL_stack_sp might change during
the call_sv().